### PR TITLE
Adds update dock properties button to dock toolbar.

### DIFF
--- a/src/quick-access-dock.cpp
+++ b/src/quick-access-dock.cpp
@@ -65,6 +65,15 @@ QuickAccessDock::~QuickAccessDock()
 	}
 }
 
+void QuickAccessDock::SetName(std::string name)
+{
+	_dockName = name;
+	auto d = parentWidget();
+	if (d) {
+		d->setWindowTitle(name.c_str());
+	}
+}
+
 void QuickAccessDock::CleanupSourceHandlers()
 {
 	if (_widget) {

--- a/src/quick-access-dock.hpp
+++ b/src/quick-access-dock.hpp
@@ -28,6 +28,7 @@ public:
 	inline void SetFilters(bool on) { _showFilters = on; }
 	inline void SetScenes(bool on) { _showScenes = on; }
 	inline void SetClickableScenes(bool on) { _clickableScenes = on; }
+	void SetName(std::string name);
 	inline QDockWidget *GetDockWidget() { return _dockWidget; }
 	void SwitchingSceneCollections(bool state) { _switchingSC = state; }
 	void SetItemsButtonVisibility();

--- a/src/quick-access-utility.cpp
+++ b/src/quick-access-utility.cpp
@@ -240,18 +240,10 @@ void QuickAccessUtility::CreateDock(CreateDockFormData data)
 	auto dockData = obs_data_create();
 	obs_data_set_string(dockData, "dock_name", data.dockName.c_str());
 	obs_data_set_string(dockData, "dock_type", data.dockType.c_str());
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(29, 1, 0)
+
 	char *dockId = os_generate_uuid();
 	obs_data_set_string(dockData, "dock_id", dockId);
 	bfree(dockId);
-#else
-	unsigned seed =
-		std::chrono::system_clock::now().time_since_epoch().count();
-	std::mt19937 rng(seed);
-	unsigned v = rng();
-	std::string dockId = std::to_string(v);
-	obs_data_set_string(dockData, "dock_id", dockId.c_str());
-#endif
 
 	obs_data_set_bool(dockData, "show_properties", data.showProperties);
 	obs_data_set_bool(dockData, "show_filters", data.showFilters);
@@ -687,6 +679,7 @@ void CreateDockDialog::on_create_dock()
 	formData.showProperties = _showProperties->isChecked();
 	formData.showFilters = _showFilters->isChecked();
 	formData.showScenes = _showScenes->isChecked();
+	formData.clickableScenes = _clickThroughScenes->isChecked();
 	formData.clickableScenes = _clickThroughScenes->isChecked();
 	qau->CreateDock(formData);
 	done(DialogCode::Accepted);

--- a/src/quick-access.cpp
+++ b/src/quick-access.cpp
@@ -19,7 +19,6 @@
 #include <QMouseEvent>
 #include <QInputDialog>
 #include <QMainWindow>
-#include <QComboBox>
 
 #include <algorithm>
 #include "version.h"

--- a/src/quick-access.cpp
+++ b/src/quick-access.cpp
@@ -18,6 +18,7 @@
 #include <QDialog>
 #include <QMouseEvent>
 #include <QInputDialog>
+#include <QMainWindow>
 
 #include <algorithm>
 #include "version.h"
@@ -585,13 +586,12 @@ QuickAccess::QuickAccess(QWidget *parent, QuickAccessDock *dock, QString name)
 	}
 
 	layout->addWidget(_sourceList);
+	_actionsToolbar = new QToolBar(this);
+	_actionsToolbar->setObjectName(QStringLiteral("actionsToolbar"));
+	_actionsToolbar->setIconSize(QSize(16, 16));
+	_actionsToolbar->setFloatable(false);
 
 	if (_dock->GetType() == "Manual") {
-		_actionsToolbar = new QToolBar(this);
-		_actionsToolbar->setObjectName(
-			QStringLiteral("actionsToolbar"));
-		_actionsToolbar->setIconSize(QSize(16, 16));
-		_actionsToolbar->setFloatable(false);
 
 		_actionAddSource = new QAction(this);
 		_actionAddSource->setObjectName(
@@ -635,23 +635,35 @@ QuickAccess::QuickAccess(QWidget *parent, QuickAccessDock *dock, QString name)
 			SLOT(on_actionSourceDown_triggered()));
 		_actionsToolbar->addAction(_actionSourceDown);
 
-		// Themes need the QAction dynamic properties
-		for (QAction *x : _actionsToolbar->actions()) {
-			QWidget *temp = _actionsToolbar->widgetForAction(x);
-
-			for (QByteArray &y : x->dynamicPropertyNames()) {
-				temp->setProperty(y, x->property(y));
-			}
-		}
-
 		_actionRemoveSource->setEnabled(false);
 		_actionSourceUp->setEnabled(false);
 		_actionSourceDown->setEnabled(false);
-
-		layout->addWidget(_actionsToolbar);
-		layout->addItem(new QSpacerItem(150, 0, QSizePolicy::Fixed,
-						QSizePolicy::Minimum));
 	}
+
+	QWidget *spacer = new QWidget();
+	spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+	_actionsToolbar->addWidget(spacer);
+
+	_actionDockProperties = new QAction(this);
+	_actionDockProperties->setObjectName(QStringLiteral("actionSourceUp"));
+	_actionDockProperties->setProperty("themeID", "propertiesIconSmall");
+	_actionDockProperties->setText(QT_UTF8(obs_module_text("Dock Props")));
+	connect(_actionDockProperties, SIGNAL(triggered()), this,
+		SLOT(on_actionDockProperties_triggered()));
+	_actionsToolbar->addAction(_actionDockProperties);
+
+	// Themes need the QAction dynamic properties
+	for (QAction *x : _actionsToolbar->actions()) {
+		QWidget *temp = _actionsToolbar->widgetForAction(x);
+
+		for (QByteArray &y : x->dynamicPropertyNames()) {
+			temp->setProperty(y, x->property(y));
+		}
+	}
+
+	layout->addWidget(_actionsToolbar);
+	layout->addItem(new QSpacerItem(150, 0, QSizePolicy::Fixed,
+					QSizePolicy::Minimum));
 
 	if (_dock->GetType() == "Dynamic") {
 		QuickAccess::SceneChangeCallback(
@@ -740,6 +752,9 @@ void QuickAccess::_LoadDynamicScenes()
 	_dynamicScenes.clear();
 	_sourceList->clear();
 
+	obs_source_t *dsk = obs_get_output_source(8);
+	const char *dsk_name = obs_source_get_name(dsk);
+	obs_source_release(dsk);
 	obs_source_t *current = obs_weak_source_get_source(_current);
 	obs_scene_t *currentScene = obs_scene_from_source(current);
 	obs_scene_enum_items(currentScene, QuickAccess::DynAddSceneItems, this);
@@ -1168,6 +1183,14 @@ void QuickAccess::on_actionRemoveSource_triggered()
 	}
 }
 
+void QuickAccess::on_actionDockProperties_triggered()
+{
+	const auto main_window =
+		static_cast<QMainWindow *>(obs_frontend_get_main_window());
+	UpdateDockDialog *dockDialog = new UpdateDockDialog(_dock, main_window);
+	dockDialog->show();
+}
+
 void QuickAccess::on_actionSourceUp_triggered()
 {
 	int index = _sourceList->currentRow();
@@ -1406,6 +1429,103 @@ void QuickAccessSceneItem::setHighlight(bool h)
 {
 	setBackgroundRole(h ? QPalette::Highlight : QPalette::Window);
 	setAutoFillBackground(h);
+}
+
+UpdateDockDialog::UpdateDockDialog(QuickAccessDock *dock, QWidget *parent)
+	: QDialog(parent),
+	  _dock(dock)
+{
+	setWindowModality(Qt::WindowModal);
+	setAttribute(Qt::WA_DeleteOnClose, true);
+	setWindowTitle(QString("Add Quick Access Dock"));
+	setMinimumWidth(400);
+	setMinimumHeight(300);
+	int labelWidth = 120;
+	_layout = new QVBoxLayout();
+
+	// Form layout
+	_layout2 = new QVBoxLayout();
+
+	auto layoutName = new QHBoxLayout();
+
+	auto inputLabel = new QLabel(this);
+	inputLabel->setText("Dock Name:");
+	inputLabel->setFixedWidth(labelWidth);
+
+	_inputName = new QLineEdit(this);
+	_inputName->setPlaceholderText("Dock Name");
+	_inputName->setText(_dock->GetName().c_str());
+	_inputName->connect(_inputName, &QLineEdit::textChanged,
+			    [this](const QString text) {
+				    _buttonBox->button(QDialogButtonBox::Ok)
+					    ->setEnabled(text.length() > 0);
+			    });
+
+	layoutName->addWidget(inputLabel);
+	layoutName->addWidget(_inputName);
+
+	_layout2->addItem(layoutName);
+
+	auto optionsLabel = new QLabel(this);
+	optionsLabel->setText("Dock Options:");
+	_layout2->addWidget(optionsLabel);
+
+	_showProperties = new QCheckBox(this);
+	_showProperties->setText("Show Properties?");
+	_showProperties->setChecked(_dock->ShowProperties());
+	_layout2->addWidget(_showProperties);
+
+	_showFilters = new QCheckBox(this);
+	_showFilters->setText("Show Filters?");
+	_showFilters->setChecked(_dock->ShowFilters());
+	_layout2->addWidget(_showFilters);
+
+	_showScenes = new QCheckBox(this);
+	_showScenes->setText("Show Parent Scenes?");
+	_showScenes->setChecked(_dock->ShowScenes());
+	_layout2->addWidget(_showScenes);
+
+	_clickThroughScenes = new QCheckBox(this);
+	_clickThroughScenes->setText("Clickable Scenes?");
+	_clickThroughScenes->setChecked(_dock->ClickableScenes());
+	_layout2->addWidget(_clickThroughScenes);
+
+	_buttonBox = new QDialogButtonBox(this);
+	_buttonBox->setStandardButtons(QDialogButtonBox::Cancel |
+				       QDialogButtonBox::Ok);
+
+	connect(_buttonBox, SIGNAL(accepted()), this, SLOT(on_update_dock()));
+	connect(_buttonBox, SIGNAL(rejected()), this, SLOT(on_cancel()));
+
+	_layout->addItem(_layout2);
+
+	// Spacer to push buttons to bottom of widget
+	QWidget *spacer = new QWidget(this);
+	spacer->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+	spacer->setVisible(true);
+	_layout->addWidget(spacer);
+
+	_layout->addWidget(_buttonBox);
+
+	setLayout(_layout);
+}
+
+void UpdateDockDialog::on_update_dock()
+{
+	blog(LOG_INFO, "Update Dock");
+	_dock->SetName(QT_TO_UTF8(_inputName->text()));
+	_dock->SetProperties(_showProperties->isChecked());
+	_dock->SetFilters(_showFilters->isChecked());
+	_dock->SetScenes(_showScenes->isChecked());
+	_dock->SetClickableScenes(_clickThroughScenes->isChecked());
+	_dock->SetItemsButtonVisibility();
+	done(DialogCode::Accepted);
+}
+
+void UpdateDockDialog::on_cancel()
+{
+	blog(LOG_INFO, "Cancel");
+	done(DialogCode::Rejected);
 }
 
 bool AddSourceToWidget(void *data, obs_source_t *source)

--- a/src/quick-access.cpp
+++ b/src/quick-access.cpp
@@ -19,6 +19,7 @@
 #include <QMouseEvent>
 #include <QInputDialog>
 #include <QMainWindow>
+#include <QComboBox>
 
 #include <algorithm>
 #include "version.h"
@@ -752,9 +753,9 @@ void QuickAccess::_LoadDynamicScenes()
 	_dynamicScenes.clear();
 	_sourceList->clear();
 
-	obs_source_t *dsk = obs_get_output_source(8);
-	const char *dsk_name = obs_source_get_name(dsk);
-	obs_source_release(dsk);
+	//obs_source_t *dsk = obs_get_output_source(8);
+	//const char *dsk_name = obs_source_get_name(dsk);
+	//obs_source_release(dsk);
 	obs_source_t *current = obs_weak_source_get_source(_current);
 	obs_scene_t *currentScene = obs_scene_from_source(current);
 	obs_scene_enum_items(currentScene, QuickAccess::DynAddSceneItems, this);

--- a/src/quick-access.hpp
+++ b/src/quick-access.hpp
@@ -13,6 +13,7 @@
 #include <QHBoxLayout>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QComboBox>
 
 #include <vector>
 #include <set>

--- a/src/quick-access.hpp
+++ b/src/quick-access.hpp
@@ -11,6 +11,8 @@
 #include <QPushButton>
 #include <QToolBar>
 #include <QHBoxLayout>
+#include <QDialog>
+#include <QDialogButtonBox>
 
 #include <vector>
 #include <set>
@@ -146,6 +148,7 @@ private:
 	QAction *_actionRemoveSource = nullptr;
 	QAction *_actionSourceUp = nullptr;
 	QAction *_actionSourceDown = nullptr;
+	QAction *_actionDockProperties = nullptr;
 	QDialog *CreateAddSourcePopupMenu();
 	obs_weak_source_t *_current = nullptr;
 	signal_handler_t *source_signal_handler = nullptr;
@@ -173,7 +176,34 @@ private slots:
 	void on_actionRemoveSource_triggered();
 	void on_actionSourceUp_triggered();
 	void on_actionSourceDown_triggered();
+	void on_actionDockProperties_triggered();
 	void on_sourceList_itemSelectionChanged();
+};
+
+class UpdateDockDialog : public QDialog {
+	Q_OBJECT
+public:
+	UpdateDockDialog(QuickAccessDock *dock, QWidget *parent = nullptr);
+
+private:
+	QuickAccessDock *_dock = nullptr;
+	QLayout *_layout = nullptr;
+	QLayout *_layout2 = nullptr;
+	//QLabel* _labelName = nullptr;
+	QLineEdit *_inputName = nullptr;
+
+	//QLabel* _labelType = nullptr;
+	QComboBox *_inputType = nullptr;
+
+	QCheckBox *_showProperties = nullptr;
+	QCheckBox *_showFilters = nullptr;
+	QCheckBox *_showScenes = nullptr;
+	QCheckBox *_clickThroughScenes = nullptr;
+
+	QDialogButtonBox *_buttonBox = nullptr;
+private slots:
+	void on_update_dock();
+	void on_cancel();
 };
 
 bool AddSourceToWidget(void *data, obs_source_t *source);


### PR DESCRIPTION
Adds a "properties" button to the right side of toolbar at the bottom of each dock.  This button opens an edit properties window which allows the user to change what features are shown in the dock (e.g.- source properties, filters, parent scenes) as well as the dock name.

Closes #42 